### PR TITLE
Update BrowserDetect.pm - Fix github URL

### DIFF
--- a/lib/Dancer2/Plugin/BrowserDetect.pm
+++ b/lib/Dancer2/Plugin/BrowserDetect.pm
@@ -69,7 +69,7 @@ keyword within your L<Dancer> application.
 
 This module is developed on Github at:
 
-L<http://github.com/hobbestigrou/Dancer2-Plugin-BrowserDetect>
+L<https://github.com/hobbestigrou/Dancer2-Plugin-Browser>
 
 Feel free to fork the repo and submit pull requests
 


### PR DESCRIPTION
Change URL from

https://github.com/hobbestigrou/Dancer2-Plugin-BrowserDetect

To:

https://github.com/hobbestigrou/Dancer2-Plugin-Browser

As per https://rt.cpan.org/Public/Bug/Display.html?id=92807
