### PR TITLE
Remove Dancer 1 dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,9 +14,6 @@ copyright_header = 2012
 ; -- Get prereqs
 [AutoPrereqs]
 
-[Prereqs]
-Dancer = 1.2001
-
 ; -- Munge files
 [NextRelease]
 [PkgVersion]


### PR DESCRIPTION
Hello!

I started installing Dancer2::Plugin::Browser, then freaked out a little when it started pulling in Dancer 1. As far as I can tell, it's not actually being used. So I updated your dist.ini to remove the Dancer 1 dependency.

Cheers!