### PR TITLE
Replace deprecated Dancer2::Test with Plack::Test

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -8,13 +8,15 @@ use lib 't/lib';
 use TestApp;
 
 use Dancer2;
-use Dancer2::Test apps => [ 'TestApp' ];;
+use Plack::Test;
+use HTTP::Request::Common;
 
 plan tests => 2;
 
 setting appdir => setting('appdir') . '/t';
 
-my $res = dancer_response GET => '/';
+my $app = Plack::Test->create( TestApp->to_app );
+my $res = $app->request( GET '/' );
 
 ok ($res);
-like $res->{content}, qr/HTTP::BrowserDetect/;
+like $res->content, qr/HTTP::BrowserDetect/;


### PR DESCRIPTION
Dancer2::Test was soft deprecated in v0.400000, and will be hard deprecated in v1.0.0 (so using it will cause a test to fail). This replaces it with Plack::Test, which is used in Dancer2's own test suite.

We're trying to be good citizens and send PRs to projects we know will be unable to install when we release Dancer2 1.0.0. Please try to get this merged ASAP, as we're maybe a week away from releasing.

Please let me know if you have any questions. Thanks!